### PR TITLE
Allow ordinary (non-async) fns in #[ritit] traits and impls.

### DIFF
--- a/examples/test_mixed_ritit.rs
+++ b/examples/test_mixed_ritit.rs
@@ -1,0 +1,28 @@
+//Compiled
+#![allow(incomplete_features)]
+
+#![feature(type_alias_impl_trait)]
+#![feature(generic_associated_types)]
+
+use async_trait_static::ritit;
+use core::future::Future;
+
+#[ritit]
+trait MixedFnTrait {
+    fn run_sync(&self, a: u8) -> i16;
+    fn run_async(&self, b: u16) -> impl Future<Output = i8>;
+}
+
+struct MixedStruct;
+
+#[ritit]
+impl MixedFnTrait for MixedStruct {
+    fn run_sync(&self, _a: u8) -> i16 { 0 }
+    fn run_async(&self, _b: u16) -> impl Future<Output = i8> { async move { 1 } }
+}
+
+fn main() {
+    let ms = MixedStruct{};
+    let _ = ms.run_sync(2);
+    let _ = async { ms.run_async(3) };
+}

--- a/src/ritit.rs
+++ b/src/ritit.rs
@@ -89,6 +89,8 @@ fn process_trait(mut input: ItemTrait) -> TokenStream {
                 let async_lifetime: GenericParam = parse_quote!('_async_lifetime);
                 func.sig.generics.params.insert(0, async_lifetime);
                 funcs.push(TraitItem::Method(func));
+            } else {
+                funcs.push(item.clone());
             }
         } else {
             asses.push(item.clone());
@@ -131,6 +133,8 @@ fn process_impl(mut input: ItemImpl) -> TokenStream {
                     type #type_name<'_async_lifetime, #generics> = impl #bounds;
                 };
                 asses.push(associated_type);
+            } else {
+                funcs.push(item.clone());
             }
         } else {
             asses.push(item.clone());


### PR DESCRIPTION
Thanks for your nice work to create this crate!